### PR TITLE
Add manifests to simplify MLDE Workspace mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ tmp
 .venv
 env/
 venv/
+
+# Specifically Service Principal files used for secrets
+kubernetes.service-principal.json

--- a/components/app-configs/mlde/workspace_config/README.md
+++ b/components/app-configs/mlde/workspace_config/README.md
@@ -1,0 +1,25 @@
+# Example manifests for creating MLDE Workspace resources in Openshift
+
+This directory intends to make a simple starting point to generate all the resources for attaching a service account for MLDE workloads, while respecting OpenShift UID rules. This is due to both products solving for running non-root containers, using different strategies.
+
+## Description
+In order to respect both product's methods for forcing non-root containers, the following logic is implemented:
+* MLDE Workloads (i.e. Notebooks and Experiments) will be forced to use a Service Account, `mlde-worker`
+    * The `mlde-worker` is permitted to use the OpenShift `nonroot` SCC policy. This means any UID is allowed, as long as it is not a root user.
+* For any workload in the same namespace that __does not specify a ServiceAccount__ to use, it will defer to `default`
+    * The `default` ServiceAccount will respect OpenShift's `restricted` SCC
+* For more details, reference https://www.redhat.com/en/blog/managing-sccs-in-openshift
+
+## Get Started
+1. Assuming you are running from this directory
+2. Copy and modify the service-principal-template to match the Service Principal being used for the Workspace.
+```
+cp kubernetes.service-principal-template.json kubernetes.service-principal.json
+```
+3. Modify `kustomization.yaml` to match the namespace that should be used. This needs to repeat for each namespace.
+    * Note: In MLDE, we generally advise keeping 1 namespace to 1 workspace
+4. Run kustomize by using
+```
+kubectl apply -k .
+```
+5. In the MLDE workspace, create a new template, using the contents of `mlde-task-template.yaml` 

--- a/components/app-configs/mlde/workspace_config/kubernetes.service-principal-template.json
+++ b/components/app-configs/mlde/workspace_config/kubernetes.service-principal-template.json
@@ -1,0 +1,8 @@
+{
+    "name": "<SP-Name>",
+    "application_id": "<ID of the Application(client), see entra app>",
+    "directory_id": "<ID of the directory/tenant, see entra app>",
+    "client_secret_id": "<client's secret id, required but not used>",
+    "client_secret_value": "<the actual secret value>",
+    "expires": "<expiry, required but not used>"
+}

--- a/components/app-configs/mlde/workspace_config/kustomization.yaml
+++ b/components/app-configs/mlde/workspace_config/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: nolan-ws
+
+resources:
+- namespace.yaml
+- worker-service-account.yaml
+- scc-kludge.yaml
+
+secretGenerator:
+- name: azure-service-principal
+  files:
+  - kubernetes.service-principal.json
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/app-configs/mlde/workspace_config/kustomization.yaml
+++ b/components/app-configs/mlde/workspace_config/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: nolan-ws
+namespace: <replace me>
 
 resources:
 - namespace.yaml

--- a/components/app-configs/mlde/workspace_config/mlde-task-template.yaml
+++ b/components/app-configs/mlde/workspace_config/mlde-task-template.yaml
@@ -1,0 +1,16 @@
+environment:
+  environment_variables: {}
+  image: nolanc/pyspark-nb:spark3.5-rapids1.12-azure3.4-autosparksession0.0.2
+  pod_spec:
+    spec:
+      serviceAccountName: mlde-worker
+      containers:
+      - name: determined-container
+        volumeMounts:
+        - name: service-principal
+          readOnly: true
+          mountPath: /azure/service_principals/
+      volumes:
+      - name: service-principal
+        secret:
+          secretName: azure-service-principal

--- a/components/app-configs/mlde/workspace_config/namespace.yaml
+++ b/components/app-configs/mlde/workspace_config/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workspace-replace-me
+  annotations:
+    openshift.io/display-name: "Determined.ai"
+    argocd.argoproj.io/sync-wave: "0"

--- a/components/app-configs/mlde/workspace_config/scc-kludge.yaml
+++ b/components/app-configs/mlde/workspace_config/scc-kludge.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: mlde-worker
-  namespace: mlde

--- a/components/app-configs/mlde/workspace_config/scc-kludge.yaml
+++ b/components/app-configs/mlde/workspace_config/scc-kludge.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mlde-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:nonroot
+subjects:
+- kind: ServiceAccount
+  name: mlde-worker
+  namespace: mlde

--- a/components/app-configs/mlde/workspace_config/worker-service-account.yaml
+++ b/components/app-configs/mlde/workspace_config/worker-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mlde-worker
+  namespace: workspace

--- a/components/app-configs/mlde/workspace_config/worker-service-account.yaml
+++ b/components/app-configs/mlde/workspace_config/worker-service-account.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mlde-worker
-  namespace: workspace


### PR DESCRIPTION
Add manifests to support MLDE workspace mapping.

This was tested on my non OpenShift cluster, just to verify that the templated ServiceAccount gets attached. The validity of the `nonroot` SCC has not been tested, nor the full implementation.

As not all users are familiar with the MLDE system, I will comment per file.